### PR TITLE
Expect.equal で Float 型を比較

### DIFF
--- a/tests/TestUtil.elm
+++ b/tests/TestUtil.elm
@@ -7,17 +7,18 @@ import Test exposing (..)
 
 testQA : String -> Fuzzer a -> (a -> r) -> (a -> r) -> Test
 testQA name f q a =
-    fuzz f name (\d1 -> Expect.equal (a d1) (q d1))
+    -- Float 型が指定された場合も比較ができるように List にしています。
+    fuzz f name (\d1 -> Expect.equal [ a d1 ] [ q d1 ])
 
 
 testQA2 : String -> Fuzzer a -> Fuzzer b -> (a -> b -> r) -> (a -> b -> r) -> Test
 testQA2 name f1 f2 q a =
-    fuzz2 f1 f2 name (\d1 d2 -> Expect.equal (a d1 d2) (q d1 d2))
+    fuzz2 f1 f2 name (\d1 d2 -> Expect.equal [ a d1 d2 ] [ q d1 d2 ])
 
 
 testQA3 : String -> Fuzzer a -> Fuzzer b -> Fuzzer c -> (a -> b -> c -> r) -> (a -> b -> c -> r) -> Test
 testQA3 name f1 f2 f3 q a =
-    fuzz3 f1 f2 f3 name (\d1 d2 d3 -> Expect.equal (a d1 d2 d3) (q d1 d2 d3))
+    fuzz3 f1 f2 f3 name (\d1 d2 d3 -> Expect.equal [ a d1 d2 d3 ] [ q d1 d2 d3 ])
 
 
 t2 : Fuzzer a -> Fuzzer b -> Fuzzer ( a, b )


### PR DESCRIPTION
refs #7

`Expect.within` を使う方法も考えましたが、手間が多いので `Expect.equal` のまま `Float` 型を扱えるようにしました。
若干トリッキーなのと誤差を許容しない点が気になりますが、elm-drill の範囲であれば問題ないと思います。