### PR TITLE
Fix: typo修正とanswer/questionで型が異なっているのを修正

### DIFF
--- a/answers/A4_Tuples.elm
+++ b/answers/A4_Tuples.elm
@@ -69,8 +69,8 @@ swap ( a, b ) =
 
 
 {-| 3つの値のうち、最後のものを取得します。
-引数 `first` `second` `thrid` はそれぞれ任意の型を表します。
-やはり、引数の型 `thrid` と戻り値の型 `thrid` は同じ型を表します。
+引数 `first` `second` `third` はそれぞれ任意の型を表します。
+やはり、引数の型 `third` と戻り値の型 `third` は同じ型を表します。
 -}
 getLast : ( first, second, third ) -> third
 getLast ( _, _, thisIsTheLastOne ) =

--- a/answers/A7_Lists.elm
+++ b/answers/A7_Lists.elm
@@ -213,7 +213,7 @@ sortByX list =
 
 
 {-| 2つのリストの要素を対にしたリストを作ります
-zip [1,2,3]["a", "b"] ==> [(1,"a"), (2,"b")]
+zip [1,2,3] ["a", "b"] ==> [(1,"a"), (2,"b")]
 -}
 zip : List a -> List b -> List ( a, b )
 zip list1 list2 =

--- a/src/Q4_Tuples.elm
+++ b/src/Q4_Tuples.elm
@@ -69,8 +69,8 @@ swap ( a, b ) =
 
 
 {-| 3つの値のうち、最後のものを取得します。
-引数 `first` `second` `thrid` はそれぞれ任意の型を表します。
-やはり、引数の型 `thrid` と戻り値の型 `thrid` は同じ型を表します。
+引数 `first` `second` `third` はそれぞれ任意の型を表します。
+やはり、引数の型 `third` と戻り値の型 `third` は同じ型を表します。
 -}
 getLast : ( first, second, third ) -> third
 getLast ( _, _, thisIsTheLastOne ) =

--- a/src/Q7_Lists.elm
+++ b/src/Q7_Lists.elm
@@ -222,5 +222,5 @@ zipWithIndex list =
 {-| 指定したインデックスの要素を削除します
 -}
 removeAt : Int -> List a -> List a
-removeAt index =
+removeAt index list =
     Debug.todo "TODO"

--- a/src/Q7_Lists.elm
+++ b/src/Q7_Lists.elm
@@ -214,7 +214,7 @@ zip list1 list2 =
 {-| インデックスと要素を対にしたリストを作ります
 zipWithIndex ["foo", "bar"] ==> [(0,"foo"), (1,"bar")]
 -}
-zipWithIndex : List a -> List ( a, b )
+zipWithIndex : List a -> List ( Int, a )
 zipWithIndex list =
     Debug.todo "TODO"
 

--- a/src/Q7_Lists.elm
+++ b/src/Q7_Lists.elm
@@ -204,7 +204,7 @@ sortByX list =
 
 
 {-| 2つのリストの要素を対にしたリストを作ります
-zip [1,2,3]["a", "b"] ==> [(1,"a"), (2,"b")]
+zip [1,2,3] ["a", "b"] ==> [(1,"a"), (2,"b")]
 -}
 zip : List a -> List b -> List ( a, b )
 zip list1 list2 =


### PR DESCRIPTION
Elmドリルに取り組んだ過程で見つけた修正です

# Changes

- コメントのtypo修正: 732c386aa86e378d431b14a6fdc09c10e23193a5
- コメントで引数間のスペースがないのを修正: 4bbd23cae3ed7908fa072904dd3a002c9513ae0f
- 型がAnswerでは `zipWithIndex : List a -> List ( Int, a )` だったがQuestionでは `zipWithIndex : List a -> List ( a, b )` だったのでAnswerに合わせるようquestion側を修正: bd051804a9000c729ded9a0f60c7c31597b874d6
- 引数がAnswerでは `removeAt index list =` だったがQuestionでは `removeAt index =` だったのでAnswer側に合わせるよう修正: 243e85ca0034333ceb2b929751ef218f0c7d5a80